### PR TITLE
feat: add option to sort result colors

### DIFF
--- a/de-CH/index.html
+++ b/de-CH/index.html
@@ -259,6 +259,14 @@
     <button id="64" class="toggle-color" data-type=paid style="background: rgb(179,185,209);" title="Light Slate: rgb(179, 185, 209)">Light Slate</button> 
       </div>
     </div>
+    <div>
+        <p class="section-title" data-i18n="sort"></p>
+        <input type="radio" name="colors-list-order" id="original" value="original" checked>
+        <label for="original" data-i18n="sortOriginal"></label>
+
+        <input type="radio" name="colors-list-order" id="used" value="used">
+        <label for="used" data-i18n="sortCount"></label>
+    </div>
     <div id="color-list" class="card span-2"></div>
   </section>
 </main>

--- a/de/index.html
+++ b/de/index.html
@@ -259,7 +259,14 @@
     <button id="63" class="toggle-color" data-type=paid style="background: rgb(109,117,141);" title="Slate: rgb(109, 117, 141)">Slate</button>
     <button id="64" class="toggle-color" data-type=paid style="background: rgb(179,185,209);" title="Light Slate: rgb(179, 185, 209)">Light Slate</button> 
     </div>
+    <div>
+        <p class="section-title" data-i18n="sort"></p>
+        <input type="radio" name="colors-list-order" id="original" value="original" checked>
+        <label for="original" data-i18n="sortOriginal"></label>
 
+        <input type="radio" name="colors-list-order" id="used" value="used">
+        <label for="used" data-i18n="sortCount"></label>
+    </div>
     <div id="color-list" class="card span-2"></div>
   </section>
 </main>

--- a/es/index.html
+++ b/es/index.html
@@ -259,6 +259,14 @@
     <button id="64" class="toggle-color" data-type=paid style="background: rgb(179,185,209);" title="Light Slate: rgb(179, 185, 209)">Light Slate</button> 
       </div>
     </div>
+    <div>
+        <p class="section-title" data-i18n="sort"></p>
+        <input type="radio" name="colors-list-order" id="original" value="original" checked>
+        <label for="original" data-i18n="sortOriginal"></label>
+
+        <input type="radio" name="colors-list-order" id="used" value="used">
+        <label for="used" data-i18n="sortCount"></label>
+    </div>
     <div id="color-list" class="card span-2"></div>
   </section>
 </main>

--- a/fr/index.html
+++ b/fr/index.html
@@ -259,6 +259,14 @@
     <button id="64" class="toggle-color" data-type=paid style="background: rgb(179,185,209);" title="Light Slate: rgb(179, 185, 209)">Light Slate</button> 
       </div>
     </div>
+    <div>
+        <p class="section-title" data-i18n="sort"></p>
+        <input type="radio" name="colors-list-order" id="original" value="original" checked>
+        <label for="original" data-i18n="sortOriginal"></label>
+
+        <input type="radio" name="colors-list-order" id="used" value="used">
+        <label for="used" data-i18n="sortCount"></label>
+    </div>
     <div id="color-list" class="card span-2"></div>
   </section>
 </main>

--- a/index.html
+++ b/index.html
@@ -271,6 +271,14 @@
     </div>
 
     <!-- Color List -->
+    <div>
+      <p class="section-title" data-i18n="sort"></p>
+      <input type="radio" name="colors-list-order" id="original" value="original" checked>
+      <label for="original" data-i18n="sortOriginal"></label>
+
+      <input type="radio" name="colors-list-order" id="used" value="used">
+      <label for="used" data-i18n="sortCount"></label>
+    </div>
     <div id="color-list" class="card span-2"></div>
   </section>
 </main>

--- a/ja/index.html
+++ b/ja/index.html
@@ -259,6 +259,14 @@
     <button id="64" class="toggle-color" data-type=paid style="background: rgb(179,185,209);" title="Light Slate: rgb(179, 185, 209)">Light Slate</button> 
       </div>
     </div>
+    <div>
+        <p class="section-title" data-i18n="sort"></p>
+        <input type="radio" name="colors-list-order" id="original" value="original" checked>
+        <label for="original" data-i18n="sortOriginal"></label>
+
+        <input type="radio" name="colors-list-order" id="used" value="used">
+        <label for="used" data-i18n="sortCount"></label>
+    </div>
     <div id="color-list" class="card span-2"></div>
   </section>
 </main>

--- a/main.js
+++ b/main.js
@@ -343,7 +343,7 @@ function getColorsListOrder() {
 }
 
 // Image processing
-let _colorCount
+let _colorCounts
 
 function processarImagem() {
   if (!canvas || !ctx) return;
@@ -409,6 +409,8 @@ function processarImagem() {
   downloadLink.download = `converted_${fileName}`;
   showImageInfo(canvas.width, canvas.height);
   if (colorCounts) showColorUsage(colorCounts);
+
+  _colorCounts = colorCounts
 
   return colorCounts;
 }
@@ -1821,6 +1823,7 @@ const colorListOrderRadio = document.querySelectorAll('input[name="colors-list-o
 
 colorListOrderRadio.forEach(radio => {
   radio.addEventListener('change', (event) => {
-    if (_colorCount) showColorUsage(_colorCount, event.target.value);
+    console.log(_colorCounts, event.target.value)
+    if (_colorCounts) showColorUsage(_colorCounts, event.target.value);
   })
 })

--- a/main.js
+++ b/main.js
@@ -1819,11 +1819,8 @@ document.addEventListener('DOMContentLoaded', () => {
   apply(); // set initial state
 });
 
-const colorListOrderRadio = document.querySelectorAll('input[name="colors-list-order"]')
-
-colorListOrderRadio.forEach(radio => {
+document.querySelectorAll('input[name="colors-list-order"]').forEach(radio => {
   radio.addEventListener('change', (event) => {
-    console.log(_colorCounts, event.target.value)
     if (_colorCounts) showColorUsage(_colorCounts, event.target.value);
   })
 })

--- a/main.js
+++ b/main.js
@@ -408,7 +408,7 @@ function processarImagem() {
   downloadLink.href = canvas.toDataURL('image/png');
   downloadLink.download = `converted_${fileName}`;
   showImageInfo(canvas.width, canvas.height);
-  if (colorCounts) showColorUsage(colorCounts);
+  if (colorCounts) showColorUsage(colorCounts, getColorsListOrder());
 
   _colorCounts = colorCounts
 

--- a/main.js
+++ b/main.js
@@ -337,8 +337,14 @@ function fitZoomToViewport() {
   return (fit > 0 && isFinite(fit)) ? fit : 1;
 }
 
+function getColorsListOrder() {
+  const fromInput = document.querySelector('input[name="colors-list-order"]:checked')?.value
+  return fromInput || 'original'
+}
 
 // Image processing
+let _colorCount
+
 function processarImagem() {
   if (!canvas || !ctx) return;
 
@@ -430,7 +436,7 @@ if (heightInput) {
 
 
 // Color usage display
-function showColorUsage(colorCounts = {}) {
+function showColorUsage(colorCounts = {}, order = 'original') {
   const colorListDiv = document.getElementById('color-list');
   if (!colorListDiv) return;
 
@@ -444,7 +450,10 @@ function showColorUsage(colorCounts = {}) {
   }).filter(item => item.count > 0 || item.hidden);
 
   colorListDiv.innerHTML = '';
-  rows.forEach(({ r, g, b, name, count, hidden }) => {
+
+  const rowsSorted = order === "original" ? rows : rows.toSorted((a, b) => b.count - a.count);
+
+  rowsSorted.forEach(({r, g, b, name, count, hidden}) => {
     const row = document.createElement('div');
     row.className = 'usage-item' + (hidden ? ' hidden' : '');
     row.style.display = 'flex';
@@ -1120,6 +1129,9 @@ const translations = {
     uploadSpan: "Click, paste or drag & drop",
     hideEyeControls: "Show color-hiding controls (eyes)",
     advancedOptions: "Advanced options",
+    sort: "Sort by",
+    sortOriginal: "Original",
+    sortCount: "Most used",
   },
   pt: {
     title: "Conversor de Cores Wplace",
@@ -1149,6 +1161,9 @@ const translations = {
     uploadSpan: "Clique, cole ou arraste e largue",
     hideEyeControls: "Mostrar controlos de ocultação de cores (olhos)",
     advancedOptions: "Opções avançadas",
+    sort: "Ordenar por",
+    sortOriginal: "Original",
+    sortCount: "Mais frequentes",
   },
   de: {
     title: "Wplace Farbkonverter",
@@ -1178,6 +1193,9 @@ const translations = {
     uploadSpan: "Klicken, einfügen oder ziehen und ablegen",
     hideEyeControls: "Farb-Ausblendsteuerung anzeigen (Augen)",
     advancedOptions: "Erweiterte Optionen",
+    sort: "Sortieren nach",
+    sortOriginal: "Original",
+    sortCount: "Am häufigsten verwendet",
   },
   es: {
     title: "Convertidor de Colores Wplace",
@@ -1207,6 +1225,9 @@ const translations = {
     uploadSpan: "Haz clic, pega o arrastra y suelta",
     hideEyeControls: "Mostrar controles para ocultar colores (ojos)",
     advancedOptions: "Opciones avanzadas",
+    sort: "Ordenar por",
+    sortOriginal: "Original",
+    sortCount: "Más usados",
   },
   fr: {
     title: "Convertisseur de Couleurs Wplace",
@@ -1236,6 +1257,9 @@ const translations = {
     uploadSpan: "Cliquez, collez ou glissez-déposez",
     hideEyeControls: "Afficher les contrôles de masquage des couleurs (yeux)",
     advancedOptions: "Options avancées",
+    sort: "Trier par",
+    sortOriginal: "Original",
+    sortCount: "Les plus utilisés",
   },
   uk: {
     title: "Конвертер кольорів Wplace",
@@ -1265,6 +1289,9 @@ const translations = {
     uploadSpan: "Натисніть, вставте або перетягніть",
     hideEyeControls: "Показати елементи керування приховуванням кольорів (очі)",
     advancedOptions: "Розширені параметри",
+    sort: "Сортувати за",
+    sortOriginal: "Оригінал",
+    sortCount: "Найбільш використовувані",
   },
   vi: {
     title: "Trình chuyển đổi màu Wplace",
@@ -1294,6 +1321,9 @@ const translations = {
     uploadSpan: "Nhấp, dán hoặc kéo và thả",
     hideEyeControls: "Hiển thị điều khiển ẩn màu (mắt)",
     advancedOptions: "Tùy chọn nâng cao",
+    sort: "Sắp xếp theo",
+    sortOriginal: "Gốc",
+    sortCount: "Sử dụng nhiều nhất",
   },
   ja: {
     title: "Wplace カラーコンバーター",
@@ -1323,6 +1353,9 @@ const translations = {
     uploadSpan: "クリック、貼り付け、またはドラッグ＆ドロップ",
     hideEyeControls: "色非表示コントロールを表示（目のアイコン）",
     advancedOptions: "詳細オプション",
+    sort: "並べ替え",
+    sortOriginal: "オリジナル",
+    sortCount: "最も使用された",
   },
   pl: {
     title: "Konwerter Kolorów Wplace",
@@ -1352,6 +1385,9 @@ const translations = {
     uploadSpan: "Kliknij, wklej lub przeciągnij i upuść",
     hideEyeControls: "Pokaż kontrolki ukrywania kolorów (oczy)",
     advancedOptions: "Opcje zaawansowane",
+    sort: "Sortuj według",
+    sortOriginal: "Oryginalne",
+    sortCount: "Najczęściej używane",
   },
   de_CH: {
     title: "Wplace Farbkonverter",
@@ -1381,6 +1417,9 @@ const translations = {
     uploadSpan: "Klicken, einfügen oder ziehen und ablegen",
     hideEyeControls: "Farb-Ausblendsteuerung anzeigen (Augen)",
     advancedOptions: "Erweiterte Optionen",
+    sort: "Sortieren nach",
+    sortOriginal: "Original",
+    sortCount: "Am häufigsten verwendet",
   },
   nl: {
     title: "Wplace Kleurconverter",
@@ -1406,6 +1445,9 @@ const translations = {
     uploadSpan: "Klik, plak of sleep en zet neer",
     hideEyeControls: "Toon kleurverbergingsknoppen (ogen)",
     advancedOptions: "Geavanceerde opties",
+    sort: "Sorteren op",
+    sortOriginal: "Origineel",
+    sortCount: "Meest gebruikt",
   },
   ru: {
     title: "Конвертер цветов Wplace",
@@ -1435,6 +1477,9 @@ const translations = {
     uploadSpan: "Нажмите, вставьте или перетащите",
     hideEyeControls: "Показать элементы управления скрытием цветов (глаза)",
     advancedOptions: "Дополнительные параметры",
+    sort: "Сортировать по",
+    sortOriginal: "Оригинал",
+    sortCount: "Наиболее используемые",
   },
   tr: {
     title: "Wplace Renk Dönüştürücü",
@@ -1464,6 +1509,9 @@ const translations = {
     uploadSpan: "Tıklayın, yapıştırın veya sürükleyip bırakın",
     hideEyeControls: "Renk gizleme kontrollerini göster (gözler)",
     advancedOptions: "Gelişmiş seçenekler",
+    sort: "Sırala",
+    sortOriginal: "Orijinal",
+    sortCount: "En çok kullanılan",
   }
 };
 
@@ -1769,3 +1817,10 @@ document.addEventListener('DOMContentLoaded', () => {
   apply(); // set initial state
 });
 
+const colorListOrderRadio = document.querySelectorAll('input[name="colors-list-order"]')
+
+colorListOrderRadio.forEach(radio => {
+  radio.addEventListener('change', (event) => {
+    if (_colorCount) showColorUsage(_colorCount, event.target.value);
+  })
+})

--- a/nl/index.html
+++ b/nl/index.html
@@ -259,6 +259,14 @@
     <button id="64" class="toggle-color" data-type=paid style="background: rgb(179,185,209);" title="Light Slate: rgb(179, 185, 209)">Light Slate</button> 
       </div>
     </div>
+    <div>
+        <p class="section-title" data-i18n="sort"></p>
+        <input type="radio" name="colors-list-order" id="original" value="original" checked>
+        <label for="original" data-i18n="sortOriginal"></label>
+
+        <input type="radio" name="colors-list-order" id="used" value="used">
+        <label for="used" data-i18n="sortCount"></label>
+    </div>
     <div id="color-list" class="card span-2"></div>
   </section>
 </main>

--- a/pl/index.html
+++ b/pl/index.html
@@ -259,6 +259,14 @@
     <button id="64" class="toggle-color" data-type=paid style="background: rgb(179,185,209);" title="Light Slate: rgb(179, 185, 209)">Light Slate</button> 
       </div>
     </div>
+    <div>
+        <p class="section-title" data-i18n="sort"></p>
+        <input type="radio" name="colors-list-order" id="original" value="original" checked>
+        <label for="original" data-i18n="sortOriginal"></label>
+
+        <input type="radio" name="colors-list-order" id="used" value="used">
+        <label for="used" data-i18n="sortCount"></label>
+    </div>
     <div id="color-list" class="card span-2"></div>
   </section>
 </main>

--- a/pt/index.html
+++ b/pt/index.html
@@ -258,6 +258,14 @@
     <button id="63" class="toggle-color" data-type=paid style="background: rgb(109,117,141);" title="Slate: rgb(109, 117, 141)">Slate</button>
     <button id="64" class="toggle-color" data-type=paid style="background: rgb(179,185,209);" title="Light Slate: rgb(179, 185, 209)">Light Slate</button> 
       </div>
+    <div>
+        <p class="section-title" data-i18n="sort"></p>
+        <input type="radio" name="colors-list-order" id="original" value="original" checked>
+        <label for="original" data-i18n="sortOriginal"></label>
+
+        <input type="radio" name="colors-list-order" id="used" value="used">
+        <label for="used" data-i18n="sortCount"></label>
+    </div>
     <div id="color-list" class="card span-2"></div>
   </section>
 </main>

--- a/ru/index.html
+++ b/ru/index.html
@@ -259,6 +259,14 @@
     <button id="64" class="toggle-color" data-type=paid style="background: rgb(179,185,209);" title="Light Slate: rgb(179, 185, 209)">Light Slate</button> 
       </div>
     </div>
+    <div>
+        <p class="section-title" data-i18n="sort"></p>
+        <input type="radio" name="colors-list-order" id="original" value="original" checked>
+        <label for="original" data-i18n="sortOriginal"></label>
+
+        <input type="radio" name="colors-list-order" id="used" value="used">
+        <label for="used" data-i18n="sortCount"></label>
+    </div>
     <div id="color-list" class="card span-2"></div>
   </section>
 </main>

--- a/tr/index.html
+++ b/tr/index.html
@@ -259,6 +259,14 @@
     <button id="64" class="toggle-color" data-type=paid style="background: rgb(179,185,209);" title="Light Slate: rgb(179, 185, 209)">Light Slate</button> 
       </div>
     </div>
+    <div>
+        <p class="section-title" data-i18n="sort"></p>
+        <input type="radio" name="colors-list-order" id="original" value="original" checked>
+        <label for="original" data-i18n="sortOriginal"></label>
+
+        <input type="radio" name="colors-list-order" id="used" value="used">
+        <label for="used" data-i18n="sortCount"></label>
+    </div>
     <div id="color-list" class="card span-2"></div>
   </section>
 </main>

--- a/uk/index.html
+++ b/uk/index.html
@@ -258,6 +258,14 @@
     <button id="64" class="toggle-color" data-type=paid style="background: rgb(179,185,209);" title="Light Slate: rgb(179, 185, 209)">Light Slate</button> 
       </div>
     </div>
+    <div>
+        <p class="section-title" data-i18n="sort"></p>
+        <input type="radio" name="colors-list-order" id="original" value="original" checked>
+        <label for="original" data-i18n="sortOriginal"></label>
+
+        <input type="radio" name="colors-list-order" id="used" value="used">
+        <label for="used" data-i18n="sortCount"></label>
+    </div>
     <div id="color-list" class="card span-2"></div>
   </section>
 </main>

--- a/vi/index.html
+++ b/vi/index.html
@@ -258,6 +258,14 @@
     <button id="64" class="toggle-color" data-type=paid style="background: rgb(179,185,209);" title="Light Slate: rgb(179, 185, 209)">Light Slate</button> 
       </div>
     </div>
+    <div>
+      <p class="section-title" data-i18n="sort"></p>
+      <input type="radio" name="colors-list-order" id="original" value="original" checked>
+      <label for="original" data-i18n="sortOriginal"></label>
+
+      <input type="radio" name="colors-list-order" id="used" value="used">
+      <label for="used" data-i18n="sortCount"></label>
+    </div>
     <div id="color-list" class="card span-2"></div>
   </section>
 </main>


### PR DESCRIPTION
## Context
This PR introduce a option to sort the colors result by original order or most used colors on processed image

⚠️ **Note**: Translations in this PR were generated with the help of AI.

## Screenshots

<img width="1290" height="803" alt="image" src="https://github.com/user-attachments/assets/626972bc-8f46-474b-af0b-5b462ba4ed6c" />
<img width="1297" height="857" alt="image" src="https://github.com/user-attachments/assets/78122e6a-cf2c-4642-8295-94c17be366bd" />
