### PR TITLE
Added a counter to display total pixels in an image

### DIFF
--- a/main.js
+++ b/main.js
@@ -453,6 +453,18 @@ function showColorUsage(colorCounts = {}, order = 'original') {
 
   colorListDiv.innerHTML = '';
 
+  //create row listing total number of pixels
+  const totalPixelCount = Object.values(colorCounts).reduce((prev, curr) => prev + curr, 0);
+  const totalRow = document.createElement('div');
+  totalRow.className = 'usage-item';
+  totalRow.style.display = 'flex';
+  totalRow.style.alignItems = 'center';
+  totalRow.style.marginBottom = '6px';
+  const totalLabel = document.createElement('span');
+  totalLabel.textContent = `Total Pixels: ${totalPixelCount}`
+  totalRow.appendChild(totalLabel);
+  colorListDiv.appendChild(totalRow);
+
   const rowsSorted = order === "original" ? rows : rows.toSorted((a, b) => b.count - a.count);
 
   rowsSorted.forEach(({r, g, b, key, name, count, hidden}) => {


### PR DESCRIPTION
I find it helpful to know how many pixels an image has so I can judge more easily if it's not too big to paint.
Therefore, I would suggest adding a label somewhere displaying the sum of all color counts together.

This PR adds an extra row at the top of the color list with the total pixel count:
<img width="456" height="289" alt="image" src="https://github.com/user-attachments/assets/82e5ab5d-25e3-4d72-bec4-26688026626d" />

Let me know if you think this could be a useful feature. I'm open to modify this further if needed, e.g. putting the counter in a different place.