### PR TITLE
Fix Duplicated 'Medium Gray' Color

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,7 +251,6 @@
         Select All 💧Paid Colors
       </button>
       <div id="colors-paid" class="chips">
-  <button id="32" class="toggle-color" data-type=paid style="background: rgb(170,170,170);" title="Medium Gray: rgb(170, 170, 170)">Medium Gray</button>
     <button id="33" class="toggle-color" data-type=paid style="background: rgb(170,170,170);" title="Medium Gray: rgb(170, 170, 170)">Medium Gray</button>
     <button id="34" class="toggle-color" data-type=paid style="background: rgb(165,14,30); color: #fff;" title="Dark Red: rgb(165,14,30)">Dark Red</button>
     <button id="35" class="toggle-color" data-type=paid style="background: rgb(250,128,114);" title="Light Red: rgb(250, 128, 114)">Light Red</button>


### PR DESCRIPTION
Should fix the paid 'Medium Gray' color from appearing twice.
Was added in PR #82 
I used the GitHub web editor, so I apologize for any funky whitespaces/newlines

<img width="468" height="234" alt="image" src="https://github.com/user-attachments/assets/74cd5ee2-f5ea-4c26-b9f2-952ce911dabf" />
